### PR TITLE
Let the tag detail bg adapts to the theme color

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -273,7 +273,7 @@ export default class ColorfulTag extends Plugin {
 		if (suffix != "") {
 			css += `.colorful-tag-popup-header:after { content: "${suffix}"; }`;
 		}
-		css += `.colorful-tag-popup-body { padding: 0 10px; border: 4px solid ${background_color}; border-radius: 0 0 10px 10px; border-top: none; background-color: #fff; }`;
+		css += `.colorful-tag-popup-body { padding: 0 10px; border: 4px solid ${background_color}; border-radius: 0 0 10px 10px; border-top: none;}`;
 		css += `.setting-item.colorful-tag-popup-item { padding: 5px 0 }`;
 		css += `#colorful-tag-popup input[type="text"] { border: none; }`;
 		css += `#colorful-tag-popup input[type="text"]:focus { border: inherit; }`;


### PR DESCRIPTION
## Before
- Dark mode:
![1111](https://user-images.githubusercontent.com/35004025/201510168-0684001b-51b2-4e31-a662-2bd98ace8fce.png)

- Light mode:
![1112](https://user-images.githubusercontent.com/35004025/201510156-fb5a3cff-0883-4924-9735-3d90f4a2c889.png)

## After
- Dark mode:
![113](https://user-images.githubusercontent.com/35004025/201510308-62597c3f-89e4-4d4a-9f7c-f4e5e5e35afd.png)

- Light mode:
![114](https://user-images.githubusercontent.com/35004025/201510182-486e71a1-879a-4f0a-8572-6c9dc48d07fe.png)

## Tested theme
Tested on Default theme, Minimal, Things, it could adapts the background color of popup-window to the theme defined color.