### PR TITLE
Fix element dislocation issue.

### DIFF
--- a/src/setting/perTagSetting.ts
+++ b/src/setting/perTagSetting.ts
@@ -61,7 +61,7 @@ export class PerTagSetting extends BaseTagSetting {
             editing_selector = `span[class*="cm-tag-${tag2}"]`;
         }
 
-        let style1 = `font-weight: ${font_weight}; background-color: ${background_color}; color: ${text_color}; font-size: ${text_size}; white-space: nowrap; border: ${border}; vertical-align: middle;`
+        let style1 = `font-weight: ${font_weight}; background-color: ${background_color}; color: ${text_color}; font-size: ${text_size}; white-space: nowrap; border: ${border}; vertical-align: top;`
         let style2 = `border-radius: ${radius}; padding-left: ${padding_size}; padding-right: ${padding_size};`
         let style3 = `border-top-right-radius: 0; border-bottom-right-radius: 0; padding-right: 0px; border-top-left-radius: ${radius}; border-bottom-left-radius: ${radius}; padding-left: ${padding_size};`
         let style4 = `border-bottom-left-radius: 0; border-top-left-radius: 0; padding-left: 0px; border-top-right-radius: ${radius}; border-bottom-right-radius: ${radius}; padding-right: ${padding_size};`

--- a/src/setting/perTagSetting.ts
+++ b/src/setting/perTagSetting.ts
@@ -71,7 +71,7 @@ export class PerTagSetting extends BaseTagSetting {
         css += `[class*="popup-${tag2}"] > .colorful-tag-popup-header { display: flex; padding: 5px 10px; background-color: ${background_color}; color: ${text_color}; font-size: ${text_size}; font-weight: ${font_weight}; border-radius: 10px 10px 0 0; }`;
         css += `[class*="popup-${tag2}"] > .colorful-tag-popup-body { padding: 0 10px; border: 4px solid ${background_color}; border-radius: 0 0 10px 10px; border-top: none;}`;
 
-        css += `body a.tag[${reading_selector}], body .cm-s-obsidian .cm-line ${editing_selector}.cm-hashtag { ${style1} }`;
+        css += `body a.tag[${reading_selector}], body .cm-s-obsidian .cm-line ${editing_selector}.cm-hashtag { ${style1}; vertical-align: bottom; }`;
         // only reading view
         css += `body a.tag[${reading_selector}] { ${style2} }`;
         // edit view begin

--- a/src/setting/perTagSetting.ts
+++ b/src/setting/perTagSetting.ts
@@ -71,7 +71,7 @@ export class PerTagSetting extends BaseTagSetting {
         css += `[class*="popup-${tag2}"] > .colorful-tag-popup-header { display: flex; padding: 5px 10px; background-color: ${background_color}; color: ${text_color}; font-size: ${text_size}; font-weight: ${font_weight}; border-radius: 10px 10px 0 0; }`;
         css += `[class*="popup-${tag2}"] > .colorful-tag-popup-body { padding: 0 10px; border: 4px solid ${background_color}; border-radius: 0 0 10px 10px; border-top: none;}`;
 
-        css += `body a.tag[${reading_selector}], body .cm-s-obsidian .cm-line ${editing_selector}.cm-hashtag { ${style1} }`;
+        css += `body a.tag[${reading_selector}], body .cm-s-obsidian .cm-line ${editing_selector}.cm-hashtag { ${style1}; vertical-align: middle; }`;
         // only reading view
         css += `body a.tag[${reading_selector}] { ${style2} }`;
         // edit view begin


### PR DESCRIPTION
Fix the prefix dislocation issue, which only happened when you use prefix but not suffix, or vice versa.

## Before
- edit mode
![before-edit](https://user-images.githubusercontent.com/35004025/208252676-955ee431-3395-465c-951b-e675d3980f26.png)

- Colorful Tag setting
![before-setting](https://user-images.githubusercontent.com/35004025/208252734-d21ba6ac-b52c-4b79-bed9-82ab4517d727.png)

## After
![after-edit](https://user-images.githubusercontent.com/35004025/208252695-2bbdf85e-2fe4-4c3a-978e-d19e833fcef4.png)

![affter-setting](https://user-images.githubusercontent.com/35004025/208252755-bce3dc8f-871a-4672-b3d6-5c2fd19698d5.png)

Tested via Obsidian Sanbox with the following themes:
- default theme
- Things